### PR TITLE
fix: Fix incorrect console log path Update generateAccount.ts

### DIFF
--- a/packages/hardhat/scripts/generateAccount.ts
+++ b/packages/hardhat/scripts/generateAccount.ts
@@ -18,7 +18,7 @@ const setNewEnvConfig = (existingEnvConfig = {}) => {
 
   // Store in .env
   fs.writeFileSync(envFilePath, stringify(newEnvConfig));
-  console.log("📄 Private Key saved to packages/hardhat/.env file");
+  console.log(`📄 Private Key saved to ${envFilePath}`);
   console.log("🪄 Generated wallet address:", randomWallet.address);
 };
 


### PR DESCRIPTION
## Description

I noticed a small inconsistency in the console log message within the `setNewEnvConfig` function. The log was hardcoding the path as `packages/hardhat/.env`, but the actual path is determined by the `envFilePath` variable, which points to `./.env`. This could be misleading if the `.env` file is located elsewhere.  

I updated the log to use the `envFilePath` variable directly, so it now correctly displays the path where the `.env` file is saved:  
```javascript  
console.log(`📄 Private Key saved to ${envFilePath}`);  
```  

This change ensures the log message accurately reflects the file's location.

## Additional Information

- [x] I have read the [contributing docs](/scaffold-eth/scaffold-eth-2/blob/main/CONTRIBUTING.md) (if this is your first contribution)
- [x] This is not a duplicate of any [existing pull request](https://github.com/scaffold-eth/scaffold-eth-2/pulls)

Your ENS/address:

0xB2fe5c3c7231B1117Da36e7B29731693fbBc6F7A