### PR TITLE
Removed all references of `monadDevnet` and updated to `monadTestnet`

### DIFF
--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -36,7 +36,7 @@ jobs:
           MONAD_RPC_URL: ${{ secrets.URL }}
           MONAD_CHAIN_ID: ${{ secrets.CHAIN_ID }}
           MONAD_EXPLORER_URL: ${{ secrets.EXPLORER }}
-        run: yarn deploy --network monadDevnet
+        run: yarn deploy --network monadTestnet
 
       - name: Run nextjs lint
         run: yarn next:lint --max-warnings=0

--- a/packages/hardhat/package.json
+++ b/packages/hardhat/package.json
@@ -13,7 +13,7 @@
     "lint": "eslint --config ./.eslintrc.json --ignore-path ./.eslintignore ./*.ts ./deploy/**/*.ts ./scripts/**/*.ts ./test/**/*.ts",
     "lint-staged": "eslint --config ./.eslintrc.json --ignore-path ./.eslintignore",
     "format": "prettier --write ./*.ts ./deploy/**/*.ts ./scripts/**/*.ts ./test/**/*.ts",
-    "test": "REPORT_GAS=true hardhat test --network monadDevnet",
+    "test": "REPORT_GAS=true hardhat test --network monadTestnet",
     "verify": "hardhat run scripts/verifyContract.ts"
   },
   "devDependencies": {

--- a/packages/nextjs/scaffold.config.ts
+++ b/packages/nextjs/scaffold.config.ts
@@ -1,4 +1,4 @@
-import { monadDevnet } from "./utils/customChains";
+import { monadTestnet } from "./utils/customChains";
 import * as chains from "viem/chains";
 
 export type ScaffoldConfig = {
@@ -11,7 +11,7 @@ export type ScaffoldConfig = {
 
 const scaffoldConfig = {
   // The networks on which your DApp is live
-  targetNetworks: [monadDevnet],
+  targetNetworks: [monadTestnet],
 
   // The interval at which your front-end polls the RPC servers for new data
   // it has no effect if you only target the local network (default is 4000)

--- a/packages/nextjs/utils/customChains.ts
+++ b/packages/nextjs/utils/customChains.ts
@@ -2,7 +2,7 @@ import { defineChain } from "viem";
 
 // TODO: Add Chain details here.
 export const monadDevnet = defineChain({
-  id: 41454,
+  id: 10143,
   name: "Monad Devnet",
   nativeCurrency: { name: "Monad", symbol: "MON", decimals: 18 },
   rpcUrls: {

--- a/packages/nextjs/utils/customChains.ts
+++ b/packages/nextjs/utils/customChains.ts
@@ -1,9 +1,9 @@
 import { defineChain } from "viem";
 
 // TODO: Add Chain details here.
-export const monadDevnet = defineChain({
+export const monadTestnet = defineChain({
   id: 10143,
-  name: "Monad Devnet",
+  name: "Monad Testnet",
   nativeCurrency: { name: "Monad", symbol: "MON", decimals: 18 },
   rpcUrls: {
     default: {
@@ -13,9 +13,9 @@ export const monadDevnet = defineChain({
   },
   blockExplorers: {
     default: {
-      name: "Monad Devnet Blockscout",
+      name: "Monad Testnet Blockscout",
       // TODO: Add Explorer URL
-      url: "<MONAD_BLOCKSCOUT_URL>",
+      url: "<MONAD_EXPLORER_URL>",
     },
   },
 });

--- a/packages/nextjs/utils/scaffold-eth/networks.ts
+++ b/packages/nextjs/utils/scaffold-eth/networks.ts
@@ -1,4 +1,4 @@
-import { monadDevnet } from "../customChains";
+import { monadTestnet } from "../customChains";
 import * as chains from "viem/chains";
 import scaffoldConfig from "~~/scaffold.config";
 
@@ -14,7 +14,7 @@ export type ChainWithAttributes = chains.Chain & Partial<ChainAttributes>;
 
 // Mapping of chainId to RPC chain name an format followed by alchemy and infura
 export const RPC_CHAIN_NAMES: Record<number, string> = {
-  [monadDevnet.id]: "monad-devnet",
+  [monadTestnet.id]: "monad-testnet",
 };
 
 export const getAlchemyHttpUrl = (chainId: number) => {
@@ -24,7 +24,7 @@ export const getAlchemyHttpUrl = (chainId: number) => {
 };
 
 export const NETWORKS_EXTRA_DATA: Record<string, ChainAttributes> = {
-  [monadDevnet.id]: {
+  [monadTestnet.id]: {
     color: "#200052",
   },
 };


### PR DESCRIPTION
## Description

Removed all references of `monadDevnet` and updated it to `monadTestnet`

To test:
- Copy `.env.example` into an `.env` file
- Enter respective values
- Run: 
```bash
yarn test
``` 

Your ENS/address:
siddhantk.eth / 0x02cba1233c543a25669dBA2A00B1806F863288BB