### PR TITLE
fix: Remove extra closing bracket in key prop

### DIFF
--- a/packages/nextjs/app/debug/_components/contract/ContractWriteMethods.tsx
+++ b/packages/nextjs/app/debug/_components/contract/ContractWriteMethods.tsx
@@ -37,7 +37,7 @@ export const ContractWriteMethods = ({
       {functionsToDisplay.map(({ fn, inheritedFrom }, idx) => (
         <WriteOnlyFunctionForm
           abi={deployedContractData.abi as Abi}
-          key={`${fn.name}-${idx}}`}
+          key={`${fn.name}-${idx}`}
           abiFunction={fn}
           onChange={onChange}
           contractAddress={deployedContractData.address}


### PR DESCRIPTION
## Description
This PR removes an unnecessary closing bracket (`}`) in the `key` prop inside `ContractWriteMethods.tsx`.
Logically, parentheses should always be in even numbers. However, there are 5 nested parentheses here, which indicates that this is incorrect.


## Additional Information

- [X] I have read the [contributing docs](/scaffold-eth/scaffold-eth-2/blob/main/CONTRIBUTING.md) (if this is your first contribution)
- [X] This is not a duplicate of any [existing pull request](https://github.com/scaffold-eth/scaffold-eth-2/pulls)

Your ENS/address: himess.eth / 0xF46b0357A6CD11935a8B5e17c329F24544eF316F
