### PR TITLE
fix: incorrect string concatenation in getFunctionInputKey

### DIFF
--- a/packages/nextjs/app/debug/_components/contract/utilsContract.tsx
+++ b/packages/nextjs/app/debug/_components/contract/utilsContract.tsx
@@ -103,7 +103,7 @@ const getInitialTupleArrayFormState = (abiTupleParameter: AbiParameterTuple) => 
   const initialForm: Record<string, any> = {};
   if (abiTupleParameter.components.length === 0) return initialForm;
   abiTupleParameter.components.forEach((component, componentIndex) => {
-    const key = getFunctionInputKey("0_" + abiTupleParameter.name || "tuple", component, componentIndex);
+    const key = getFunctionInputKey((abiTupleParameter.name ? "0_" + abiTupleParameter.name : "tuple"), component, componentIndex);
     initialForm[key] = "";
   });
   return initialForm;


### PR DESCRIPTION
## Description
This PR fixes an issue in the `getFunctionInputKey` function where incorrect string concatenation was causing unintended key generation.

Previously, the expression `"0_" + abiTupleParameter.name || "tuple"` had an incorrect precedence.  
As a result, if `abiTupleParameter.name` was undefined or an empty string, `"0_"` would be used instead of `"tuple"`, leading to incorrect key generation.

The original code assumes that `abiTupleParameter.name` can be `undefined` or an empty string.  
If this was never a possibility, then the `"tuple"` fallback would not have been included in the first place.

If `abiTupleParameter.name` was always defined and a non-empty string,
then `|| "tuple"` would not be necessary.

However, since `"tuple"` was included, it indicates that `undefined` or `""` (empty string) is a valid scenario.
The incorrect operator precedence caused `"0_"` to be used instead of `"tuple"` in these cases.

## Fix
- Updated the expression to ensure the correct fallback value is applied:  
  **Old:** `"0_" + abiTupleParameter.name || "tuple"`  
  **New:** `abiTupleParameter.name ? "0_" + abiTupleParameter.name : "tuple"`

This fix ensures that `"tuple"` is correctly used when `abiTupleParameter.name` is undefined or empty, preventing potential key mismatches in form handling.

## Additional Information

- [X] I have read the [contributing docs](/scaffold-eth/scaffold-eth-2/blob/main/CONTRIBUTING.md) (if this is your first contribution)
- [X] This is not a duplicate of any [existing pull request](https://github.com/scaffold-eth/scaffold-eth-2/pulls)


Your ENS/address: himess.eth / 0xF46b0357A6CD11935a8B5e17c329F24544eF316F
