### PR TITLE
fix: Correct broken links to contributing docs and PRs

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -4,8 +4,8 @@ _Concise description of proposed changes, We recommend using screenshots and vid
 
 ## Additional Information
 
-- [ ] I have read the [contributing docs](/scaffold-eth/scaffold-eth-2/blob/main/CONTRIBUTING.md) (if this is your first contribution)
-- [ ] This is not a duplicate of any [existing pull request](https://github.com/scaffold-eth/scaffold-eth-2/pulls)
+- [ ] I have read the [contributing docs](https://github.com/monad-developers/scaffold-eth-monad/blob/main/CONTRIBUTING.md) (if this is your first contribution)
+- [ ] This is not a duplicate of any [existing pull request](https://github.com/monad-developers/scaffold-eth-monad/pulls)
 
 ## Related Issues
 


### PR DESCRIPTION
## Description

First of all, the link **/scaffold-eth/scaffold-eth-2/blob/main/CONTRIBUTING.md** was broken because it was missing "github.com" at the beginning. Apart from that, I updated the links to match the correct references in this repository. 

The previous links were incorrectly pointing to **scaffold-eth/scaffold-eth-2**, whereas now they correctly redirect to **monad-developers/scaffold-eth-monad/**.

Your ENS/address: himess.eth / 0xF46b0357A6CD11935a8B5e17c329F24544eF316F
