### PR TITLE
fix: update color for monadTestnet in NETWORKS_EXTRA_DATA

### DIFF
--- a/packages/nextjs/utils/scaffold-eth/networks.ts
+++ b/packages/nextjs/utils/scaffold-eth/networks.ts
@@ -25,7 +25,7 @@ export const getAlchemyHttpUrl = (chainId: number) => {
 
 export const NETWORKS_EXTRA_DATA: Record<string, ChainAttributes> = {
   [monadTestnet.id]: {
-    color: "#fffff",
+    color: "#ffffff",
   },
 };
 

--- a/packages/nextjs/utils/scaffold-eth/networks.ts
+++ b/packages/nextjs/utils/scaffold-eth/networks.ts
@@ -25,7 +25,7 @@ export const getAlchemyHttpUrl = (chainId: number) => {
 
 export const NETWORKS_EXTRA_DATA: Record<string, ChainAttributes> = {
   [monadTestnet.id]: {
-    color: "#200052",
+    color: "#fffff",
   },
 };
 


### PR DESCRIPTION
## Description

_Concise description of proposed changes, We recommend using screenshots and videos for better description_

before modification

<img width="498" alt="image" src="https://github.com/user-attachments/assets/384058d0-2f22-44cb-8f87-1d0673903c1e" />

after modification

<img width="476" alt="image" src="https://github.com/user-attachments/assets/8da64023-07dc-49de-af1e-a513a29c2302" />

## Additional Information

- [x] I have read the [contributing docs](/scaffold-eth/scaffold-eth-2/blob/main/CONTRIBUTING.md) (if this is your first contribution)
- [x] This is not a duplicate of any [existing pull request](https://github.com/scaffold-eth/scaffold-eth-2/pulls)

Your ENS/address: 0x22808912E21FE9923ab421741eDD99C611A2661C
